### PR TITLE
Add metadata tags for search engines and social networks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'jekyll-seo-tag'
 gemspec

--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,5 @@
 repository: DNNCommunity/DNN.FormAndList
 markdown: kramdown
 highlighter: rouge
+plugins:
+  - jekyll-seo-tag

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" type="text/css" href="assets/css/style.css" />
     <link rel="stylesheet" type="text/css" href="assets/css/syntax.css" />
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+    {% seo %}
 </head>
 <body>  
     {% include header.html %}


### PR DESCRIPTION
Added the **jekyll-seo-tag** plugin to the project.  Thanks to @EPTamminga for mentioning the need to add SEO tags to the theme.

Resolves #11 

Here is an excerpt from the **jekyll-seo-tag** plugin [README](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/README.md):

## About Jekyll SEO Tag

A Jekyll plugin to add metadata tags for search engines and social networks to better index and display your site's content.

## What it does

Jekyll SEO Tag adds the following meta tags to your site:

* Page title, with site title or description appended
* Page description
* Canonical URL
* Next and previous URLs on paginated pages
* [JSON-LD Site and post metadata](https://developers.google.com/structured-data/) for richer indexing
* [Open Graph](http://ogp.me/) title, description, site title, and URL (for Facebook, LinkedIn, etc.)
* [Twitter Summary Card](https://dev.twitter.com/cards/overview) metadata

While you could theoretically add the necessary metadata tags yourself, Jekyll SEO Tag provides a battle-tested template of crowdsourced best-practices.

## What it doesn't do

Jekyll SEO tag is designed to output machine-readable metadata for search engines and social networks to index and display. If you're looking for something to analyze your Jekyll site's structure and content (e.g., more traditional SEO optimization), take a look at [The Jekyll SEO Gem](https://github.com/pmarsceill/jekyll-seo-gem).

Jekyll SEO tag isn't designed to accommodate every possible use case. It should work for most site out of the box and without a laundry list of configuration options that serve only to confuse most users.

## Documentation

For more information, see:

* [Installation](installation.md)
* [Usage](usage.md)
* [Advanced usage](advanced-usage.md)