### PR TITLE
Added conditional logic to apply 'active' class for Home page

### DIFF
--- a/_includes/sidemenu.html
+++ b/_includes/sidemenu.html
@@ -4,7 +4,7 @@
         {% assign links = site.data.navigation %}
         {% for link in links}
             {% assign class = nil %}
-            {% if page.url contains link.url %}
+            {% if page.url contains link.url or (forloop.first and page.path contains 'index.md') %}
                 {% assign class = 'active' %}
             {% endif %}
             {% if link.sublinks %}


### PR DESCRIPTION
Unfortunately, `page.url` is not adequate for detecting the default document for the site, `index.html`.  Therefore, I had to result to using a combination of `forloop.first` and `page.path` to detect the first item and what markdown file is being loaded.
Resolves #15 